### PR TITLE
Fix: various bug fixes for v3.1.1

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -43,10 +43,10 @@ export default function ProfilePage() {
       router.push('/');
       return;
     }
-    if (status === 'authenticated' && user?.nickname) {
-      console.log(user.nickname);
-      setNickname(user.nickname);
-      oldNickname.current = user.nickname;
+    if (status === 'authenticated' && (user?.nickname || user?.name)) {
+      const name = user.nickname ?? user.name ?? '';
+      setNickname(name);
+      oldNickname.current = name;
     }
   }, [user, status]);
 

--- a/lib/hooks/useFirebaseAuth.ts
+++ b/lib/hooks/useFirebaseAuth.ts
@@ -78,13 +78,17 @@ export function useFirebaseAuth() {
               (await updateUIDIfNotExist(user.email, currentUser.uid));
             setUser(user);
             setStatus('authenticated');
-            toast({ title: 'Welcome Back!' });
+            toast({ title: 'Welcome Back! ' + user.nickname });
           } else {
             // new user
             const newUser = await updateUserFromAuth(currentUser);
             setUser(newUser);
             setStatus('authenticated');
-            toast({ title: 'Welcome to Taboo AI!!' });
+            toast({
+              title:
+                'Hi ' + newUser.nickname ??
+                newUser.name + '! Welcome to Taboo AI!',
+            });
           }
         } catch (error) {
           console.log(error.message);

--- a/lib/services/gameService.ts
+++ b/lib/services/gameService.ts
@@ -29,6 +29,7 @@ export const uploadCompletedGameForUser = async (
   const finishedAt = existingGameRef.data()?.finishedAt;
   // Create the game document
   await setDoc(gameRef, {
+    levelId: levelId,
     levelRef: doc(firestore, 'levels', levelId),
     finishedAt: finishedAt ?? game.finishedAt,
     totalScore: game.totalScore,

--- a/lib/services/levelService.ts
+++ b/lib/services/levelService.ts
@@ -183,7 +183,7 @@ export const updateRealtimeDBLevelRecord = async (
   const prevTopScorerEmail = currentRecord.val()?.topScorer ?? scorer.email;
   const prevTopScorerNickname =
     currentRecord.val()?.topScorerName ?? scorer.nickname ?? 'Anonymous';
-  const updates = {
+  const levelStat = {
     topScore: Math.max(prevTopScore, score),
     topScorer: prevTopScore > score ? prevTopScorerEmail : scorer.email,
     topScorerName:
@@ -191,9 +191,9 @@ export const updateRealtimeDBLevelRecord = async (
         ? prevTopScorerNickname
         : scorer.anonymity
         ? 'Anonymous'
-        : scorer.nickname,
+        : scorer.nickname ?? scorer.name ?? 'Anonymous',
   };
-  await update(child(ref(realtime, 'levelStats'), levelID), updates);
+  await update(child(ref(realtime, 'levelStats'), levelID), levelStat);
 };
 
 /**

--- a/lib/services/levelService.ts
+++ b/lib/services/levelService.ts
@@ -180,13 +180,15 @@ export const updateRealtimeDBLevelRecord = async (
 ): Promise<void> => {
   const currentRecord = await get(child(ref(realtime, 'levelStats'), levelID));
   const prevTopScore = currentRecord.val()?.topScore ?? -Infinity;
-  const prevTopScorer = currentRecord.val()?.topScorer ?? undefined;
+  const prevTopScorerEmail = currentRecord.val()?.topScorer ?? scorer.email;
+  const prevTopScorerNickname =
+    currentRecord.val()?.topScorerName ?? scorer.nickname ?? 'Anonymous';
   const updates = {
     topScore: Math.max(prevTopScore, score),
-    topScorer: prevTopScore > score ? prevTopScorer : scorer.email,
+    topScorer: prevTopScore > score ? prevTopScorerEmail : scorer.email,
     topScorerName:
       prevTopScore > score
-        ? prevTopScorer
+        ? prevTopScorerNickname
         : scorer.anonymity
         ? 'Anonymous'
         : scorer.nickname,

--- a/lib/services/levelService.ts
+++ b/lib/services/levelService.ts
@@ -142,19 +142,21 @@ export const uploadPlayedLevelForUser = async (
   const levelRef = doc(firestore, 'users', email, 'levels', level.id);
   const levelSnapshot = await getDoc(levelRef);
   if (!levelSnapshot.exists()) {
-    await setDoc(levelRef, {
-      lastPlayedAt: playedAt,
-      bestScore: score,
-      attempts: increment(1),
-      ref: doc(firestore, 'levels', level.id),
-    });
+    await setDoc(
+      levelRef,
+      {
+        lastPlayedAt: playedAt,
+        bestScore: score,
+        ref: doc(firestore, 'levels', level.id),
+      },
+      { merge: true }
+    );
   } else {
     const levelData = levelSnapshot.data();
     if (levelData) {
       const lastPlayedAt = levelData.lastPlayedAt;
       const bestScore = levelData.bestScore;
       await updateDoc(levelRef, {
-        attempts: increment(1),
         lastPlayedAt: lastPlayedAt > playedAt ? lastPlayedAt : playedAt,
         bestScore: bestScore > score ? bestScore : score,
       });

--- a/lib/types/user.type.ts
+++ b/lib/types/user.type.ts
@@ -1,8 +1,8 @@
 export default interface IUser {
   uid?: string;
   email: string;
-  name?: string;
-  nickname?: string;
+  name?: string; // Name from google auth
+  nickname?: string; // Player custom name
   photoUrl?: string;
   firstLoginAt?: string;
   lastLoginAt?: string;


### PR DESCRIPTION
- Ranking page reminder to login to get rank recorded
- Fix nickname / name confusion when updating db
- Users levels/ document attempted count should be auto updated by cloud function when a game is created (in-sync)
- When user gets deleted, all sub collections should be deleted, and realtime db will delete the record if the user is the top scorer (note: that will make the topic without a top scorer, even though there are other players scores at second place but this won't be updated!)